### PR TITLE
Make the plugin version agnostic

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -8,7 +8,7 @@ namespace Gaylatea
 {
     namespace UseLooseLoot
     {
-        [BepInPlugin("com.gaylatea.uselooseloot", "SPT-UseLooseLoot", "1.0.0")]
+        [BepInPlugin("com.gaylatea.uselooseloot", "SPT-UseLooseLoot", "1.1.0")]
         public class Plugin : BaseUnityPlugin
         {
             internal static ManualLogSource logger;


### PR DESCRIPTION
- Switch to using pure reflection for method, field and type lookups
- Use the parameter names to find the target method, instead of the method name
- Plugin should now be compatible with future SPT versions without a rebuild necessary